### PR TITLE
Suggest to clear the cache when the seafile directory has changed.

### DIFF
--- a/deploy/deploy_Seahub_at_Non-root_domain.md
+++ b/deploy/deploy_Seahub_at_Non-root_domain.md
@@ -115,6 +115,16 @@ You need to add a line in <code>seahub_settings.py</code> to set the value of `F
 FILE_SERVER_ROOT = 'http://www.myseafile.com/seafhttp'
 ```
 
+## Clear the cache
+
+Seafile stores for example the link to the avatar icon in /tmp/seahub_cache/ as long as memcache is not used. We suggest to clear the cache after seafile has been stopped:
+
+<pre>
+rm -rf /tmp/seahub_cache/
+</pre>
+
+For memcache users, please purge the cache there instead.
+
 ## Start Seafile and Seahub
 
 <pre>


### PR DESCRIPTION
Hi

This patch suggests that a user should clear the cache when the directory of seafile on the webserver has changed, to that all links to the old directory location that are still stored in the cache should be updated. It should prevent what was reported in:

https://github.com/haiwen/seafile/issues/355