### PR TITLE
correct syntax for "FILE_SERVER_ROOT" in seahub_settings.py

### DIFF
--- a/deploy/deploy_with_apache.md
+++ b/deploy/deploy_with_apache.md
@@ -132,7 +132,7 @@ Note: If you later change the domain assigned to seahub, you also need to change
 You need to add a line in <code>seahub_settings.py</code> to set the value of `FILE_SERVER_ROOT` (or `HTTP_SERVER_ROOT` before version 3.1)
 
 ```python
-FILE_SERVER_ROOT = 'http://www.myseafile.com/seafhttp'
+'FILE_SERVER_ROOT' : 'http://www.myseafile.com/seafhttp',
 ```
 
 ## Start Seafile and Seahub

--- a/deploy/https_with_apache.md
+++ b/deploy/https_with_apache.md
@@ -67,7 +67,7 @@ SERVICE_URL = https://www.myseafile.com
 You need to add a line in seahub_settings.py to set the value of `FILE_SERVER_ROOT` (Or `HTTP_SERVER_ROOT` before version 3.1.0)
 
 ```python
-FILE_SERVER_ROOT = 'https://www.myseafile.com/seafhttp'
+'FILE_SERVER_ROOT' : 'http://www.myseafile.com/seafhttp',
 ```
 
 ## Start Seafile and Seahub

--- a/deploy/https_with_apache.md
+++ b/deploy/https_with_apache.md
@@ -67,7 +67,7 @@ SERVICE_URL = https://www.myseafile.com
 You need to add a line in seahub_settings.py to set the value of `FILE_SERVER_ROOT` (Or `HTTP_SERVER_ROOT` before version 3.1.0)
 
 ```python
-'FILE_SERVER_ROOT' : 'http://www.myseafile.com/seafhttp',
+'FILE_SERVER_ROOT' : 'https://www.myseafile.com/seafhttp',
 ```
 
 ## Start Seafile and Seahub


### PR DESCRIPTION
FILE_SERVER_ROOT in seahub_settings.py has to be use this ":" instead of "=" between key and value.

Correct line is:
'FILE_SERVER_ROOT' : 'https://intranet.hyhelp.de/seafhttp';, 

and not

FILE_SERVER_ROOT = 'https://www.myseafile.com/seafhttp';

as in current documentation