### PR TITLE
deploy_pro/search_and_background: start seahub

### DIFF
--- a/deploy_pro/enable_search_and_background_tasks_in_a_cluster.md
+++ b/deploy_pro/enable_search_and_background_tasks_in_a_cluster.md
@@ -73,13 +73,17 @@ OFFICE_CONVERTOR_ROOT = http://<ip of node A>
 
 ## Start the background tasks
 
-Before starting background tasks, you have to start seafile on the background node too.
+Before starting background tasks, you have to start seafile and seahub on the background node, too.
 
 ```
 ./seafile.sh start
+# depending on config without fastcgi:
+./seahub.sh start  
+# or with fastcgi:
+./seahub.sh start-fastcgi
 ```
 
-On node A (the background tasks node), you can star/stop background tasks by:
+On node A (the background tasks node), you can start/stop background tasks by:
 
 ```
 ./seafile-background-tasks.sh { start | stop | restart }


### PR DESCRIPTION
At least during my tests I needed to start seahub as well to get a working background node.