### PR TITLE
Clarified hardcoded /seafhttp path for non-root deployment

### DIFF
--- a/deploy/deploy_seahub_at_non-root_domain.md
+++ b/deploy/deploy_seahub_at_non-root_domain.md
@@ -1,5 +1,5 @@
 # Deploy Seahub at Non-root domain
-This documentation will talk about how to deploy Seafile Web using Apache/Nginx at Non-root directory of the website(e.g., www.example.com/seafile/).
+This documentation will talk about how to deploy Seafile Web using Apache/Nginx at Non-root directory of the website(e.g., www.example.com/seafile/). Please note that the file server path will still be e.g. www.example.com/seafhttp (rather than www.example.com/seafile/seafhttp) because this path is hardcoded in the clients.
 
 **Note:** We assume you have read [Deploy Seafile with nginx](deploy_with_nginx.md) or [Deploy Seafile with apache](deploy_with_apache.md).
 
@@ -119,6 +119,7 @@ You need to add a line in <code>seahub_settings.py</code> to set the value of `F
 ```python
 FILE_SERVER_ROOT = 'http://www.myseafile.com/seafhttp'
 ```
+**Note:** The file server path MUST be `/seafhttp` because this path is hardcoded in the clients.
 
 ## Clear the cache
 


### PR DESCRIPTION
Several people had problems with the hardcoded /seafhttp file server path. This change clarifies the issue when deploying seafile for a non-root domain: https://github.com/haiwen/seafile/issues/1224