### PR TITLE
Fix for Shibboleth config example

### DIFF
--- a/deploy/shibboleth_config.md
+++ b/deploy/shibboleth_config.md
@@ -51,9 +51,6 @@ You should create a new virtual host configuration for Shibboleth.
 
         <Location /Shibboleth.sso>
         SetHandler shib
-        AuthType shibboleth
-        ShibRequestSetting requireSession true
-        Require valid-user
         </Location>
 
         <Location /api2>
@@ -86,6 +83,7 @@ You should create a new virtual host configuration for Shibboleth.
         #
         RewriteRule ^/(media.*)$ /$1 [QSA,L,PT]
         RewriteCond %{REQUEST_FILENAME} !-f
+        RewriteCond %{REQUEST_URI} !^/Shibboleth.sso
         RewriteRule ^(.*)$ /seahub.fcgi$1 [QSA,L,E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 
     </VirtualHost>


### PR DESCRIPTION
Shibboleth.sso is for receiving answers from identity provider. You
can't protect shibboleth with shibboleth.
Another configuration error combined with this misconfiguration made me
DoS my identity provider (error answer creates new request, redirect
loop in browser).
Furthermore I needed to prevent Apache from sending Shibboleth.sso requests
to seafile. It's not of its business.

Fixes #101