### PR TITLE
nginx: Fix rewrite rule used for non-root domains

### DIFF
--- a/deploy/deploy_seahub_at_non-root_domain.md
+++ b/deploy/deploy_seahub_at_non-root_domain.md
@@ -49,7 +49,7 @@ server {
     }
 
     location /seafhttp {
-        rewrite ^/seafhttp(.*)$ $1 break;
+        rewrite ^/seafhttp/(.*)$ /$1 break;
         proxy_pass http://127.0.0.1:8082;
         client_max_body_size 0;
     }


### PR DESCRIPTION
The current rewrite rule results in a request for e.g. '/seafhttp/protocol-version'
to be rewritten as '//protocol-version' which results in a 404 by the file server.
Just adding an extra '/' fixes this. Also see
https://forum.seafile-server.org/t/client-cannot-sync-but-fetch-library-info-over-https/3639
