### PR TITLE
Update deploy_with_nginx.md

### DIFF
--- a/deploy/deploy_with_nginx.md
+++ b/deploy/deploy_with_nginx.md
@@ -42,6 +42,7 @@ server {
 
         access_log      /var/log/nginx/seahub.access.log;
     	error_log       /var/log/nginx/seahub.error.log;
+    	fastcgi_read_timeout 36000;
     }
 
     location /seafhttp {
@@ -51,6 +52,7 @@ server {
         proxy_connect_timeout  36000s;
         proxy_read_timeout  36000s;
         proxy_send_timeout  36000s;
+        send_timeout  36000s;
     }
 
     location /media {


### PR DESCRIPTION
Added values to have the trash page not timeout on the browser site. Browser doesn't wait that long otherwise and will show a white page or a timeout window. Had to fiddle a while to get it working with these values.
Same changes to nginx with SSL.