### PR TITLE
Clarify: ldap libs need to be moved every upgrade

### DIFF
--- a/deploy/using_ldap.md
+++ b/deploy/using_ldap.md
@@ -129,4 +129,7 @@ mkdir disabled_libs_use_local_ones_instead
 mv libnssutil3.so disabled_libs_use_local_ones_instead/
 ```
 
-This effectively removes the bundled libraries from the library search path. When the server starts, it'll instead find the system libraries (if they are installed).
+This effectively removes the bundled libraries from the library search path. 
+When the server starts, it'll instead find and use the system libraries (if they are installed). 
+This change has to be repeated after each update of the Seafile installation.
+

--- a/deploy_pro/using_ldap_pro.md
+++ b/deploy_pro/using_ldap_pro.md
@@ -227,21 +227,26 @@ The current version of Seafile Linux server package is compiled on CentOS. We in
 
 The ldap library (libldap) bundled in the Seafile package is of version 2.4. If your Linux distribution is new enough (like CentOS 6, Debian 7 or Ubuntu 12.04 or above), you can use system's libldap instead.
 
-On Ubuntu 14.04, moving the bundled ldap related libraries out of the library path should make TLS connection works.
+On Ubuntu 14.04 and Debian 7/8, moving the bundled ldap related libraries out of the library path should make TLS connection work.
 
 ```
 cd ${SEAFILE_INSTALLATION_DIR}/seafile-server-latest/seafile/lib
-mv liblber-2.4.so.2 libldap-2.4.so.2 libsasl2.so.2 ..
+mkdir disabled_libs_use_local_ones_instead
+mv liblber-2.4.so.2 libldap-2.4.so.2 libsasl2.so.2 libldap_r-2.4.so.2 disabled_libs_use_local_ones_instead/
 ```
 
 On CentOS 6, you have to move the libnssutil library:
 
 ```
 cd ${SEAFILE_INSTALLATION_DIR}/seafile-server-latest/seafile/lib
-mv libnssutil3.so ..
+mkdir disabled_libs_use_local_ones_instead
+mv libnssutil3.so disabled_libs_use_local_ones_instead/
 ```
 
-This effectively remove the bundled libraries out of the library path. When the server runs, it'll look for corresponding libraries from the system paths.
+This effectively removes the bundled libraries from the library search path. 
+When the server starts, it'll instead find and use the system libraries (if they are installed). 
+This change has to be repeated after each update of the Seafile installation.
+
 
 ### Use paged results extension
 


### PR DESCRIPTION
If the system's LDAP libs are to be used, the Seafile-packaged ldap libs have to be (re)moved after every upgrade.
This is easy to forget. Together with my previous commits this completely replaces haiwen/seafile-docs#123 (which can therefore be closed without merging)