### PR TITLE
Added information on how to run seaf-fsck.exe under Windows.

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -39,6 +39,7 @@
    * [Upgrading Seafile Windows Server](deploy_windows/upgrading_seafile_windows_server.md)
    * [Migrate Seafile From Windows To Linux](deploy_windows/migrate_from_win_to_linux.md)
    * [Garbage Collecting Unused Blocks on Seafile Server](deploy_windows/windows_gc.md)
+   * [Running seaf-fsck on corrupted repositories](deploy_windows/windows_fsck.md)
 * [Deploy Seafile Pro Edition](deploy_pro/README.md)
    * [Download and Setup Seafile Professional Server](deploy_pro/download_and_setup_seafile_professional_server.md)
    * [Migrate from Seafile Community Server](deploy_pro/migrate_from_seafile_community_server.md)

--- a/deploy_windows/deploy_with_windows.md
+++ b/deploy_windows/deploy_with_windows.md
@@ -19,6 +19,7 @@ For more information on Seafile server, check the documents on [Seafile Linux ve
 ## Server Administration
 
 - [Garbage Collecting Unused Blocks on Seafile Server](windows_gc.md)
+- [Running seaf-fsck on corrupted repositories](windows_fsck.md)
 
 ## Common Issues
 

--- a/deploy_windows/windows_fsck.md
+++ b/deploy_windows/windows_fsck.md
@@ -1,0 +1,17 @@
+
+### Running seaf-fsck on corrupted repositories ###
+
+For the time being there is no batch file available for running `seaf-fsck.exe` in a Windows environment.
+To manually run `seaf-fsck.exe`, follow the following procedure (assuming you've installed Seafile server to `X:\Seafile\`:
+
+1. Open a command prompt by following *either* of these steps
+  - Click **Start**, **Run**, enter `cmd.exe` and then navigate to the binary folder by entering `cd /d X:\Seafile\seafile-server-5.x.x\seafile\bin`
+  - Or, using the file explorer:
+    * Navigate to the folder where the binaries are located (`X:\Seafile\seafile-server-5.x.x\seafile\bin`)
+    * Hold shift and right click in free space to bring up the context menu, then select **Open command window here**
+2. Enter the following inside the opened command prompt: `seaf-fsck.exe --repair -c Y:\seafile-user\ccnet -d Y:\seafile-user\seafile-data -F Y:\seafile-user\conf`
+  - *seafile-user* is the folder your Seafile data is stored in
+  - Make sure you are pointing `seaf-fsck.exe` towards the correct directory: *ccnet*, *seafile-data* and *conf* folders must be present
+3. `seaf-fsck` should be running now
+
+For information on *seaf-fsck*, its usage and syntax, see the chapter [Seafile FSCK](../maintain/seafile_fsck.md).


### PR DESCRIPTION
Documented the basic syntax to run seaf-fsck while in a Windows environment (as pointed out by *Jia Qiang Xu* in thread: [Error running seaf-fsck on Windows Server](https://forum.seafile-server.org/t/error-running-seaf-fsck-on-windows-server/4570)).

Feel free to notify me of needed corrections.