### PR TITLE
log_bin instead of log-bin

### DIFF
--- a/deploy_pro/real_time_backup.md
+++ b/deploy_pro/real_time_backup.md
@@ -52,7 +52,7 @@ On the primary server, add following options to my.cnf:
 
 ```
 [mysqld]
-log-bin=mysql-bin
+log_bin=mysql-bin
 server-id=1
 ```
 


### PR DESCRIPTION
Shouldn't it be log_bin? It is the default in /etc/mysql/my.cnf on Debian. Also see: http://dev.mysql.com/doc/refman/5.7/en/replication-options-binary-log.html