### PR TITLE
Fixed the missing part in "using external elasticsearch server".

### DIFF
--- a/deploy_pro/details_about_file_search.md
+++ b/deploy_pro/details_about_file_search.md
@@ -39,10 +39,12 @@ Restart your ES server after this.
 ```
 [INDEX FILES]
 ...
+external_es_server = true
 es_host = 192.168.1.101
 es_port = 9500
 ```
 
+- `external_es_server`: set to `true` so seafile would not start its own elasticsearch server
 - `es_host`: The ip address of your ES server
 - `es_port`: The listening port of the Thrift transport module. By default it should be `9500`
 


### PR DESCRIPTION
The config `external_es_server` need to be to use an external elasticsearch server. It's described in the docs about "running in a cluster", but missing in `details_about_file_search.md` .