### PR TITLE
Missing export

### DIFF
--- a/deploy/using_postgresql.md
+++ b/deploy/using_postgresql.md
@@ -67,6 +67,7 @@
 4. Start seahub as follows (assume current path is `/data/haiwen/seafile-server-1.7.0`:
 
         export CCNET_CONF_DIR=/data/haiwen/ccnet
+        export SEAFILE_CENTRAL_CONF_DIR=/data/haiwen/conf
         export SEAFILE_CONF_DIR=/data/haiwen/seafile-data
         INSTALLPATH=/data/haiwen/seafile-server-1.7.0
         export PYTHONPATH=${INSTALLPATH}/seafile/lib/python2.6/site-packages:${INSTALLPATH}/seafile/lib64/python2.6/site-packages:${INSTALLPATH}/seahub/thirdpart:$PYTHONPATH


### PR DESCRIPTION
Due to missing environment variable, importer tries to get ccnet.conf from  unable to apply migrations (ccnet), but it actually placed in conf/ dir, which should be in SEAFILE_CENTRAL_CONF_DIR variable