### PR TITLE
fix links to libreoffice

### DIFF
--- a/deploy_pro/office_documents_preview.md
+++ b/deploy_pro/office_documents_preview.md
@@ -1,43 +1,43 @@
-Seafile Professional server supports previewing office/pdf documents online by converting them to HTML pages. You can follow the steps described on this page to use this feature. If you'd like to edit office files online, you can integrate Seafile with Microsoft Office Online server or LibreOffice online.
+Seafile Professional Server supports previewing office/pdf documents online by converting them to HTML pages. You can follow these steps to use the feature. If you'd like to edit office files online, you can integrate Seafile with Microsoft Office Online server, LibreOffice online or OnlyOffice.
 
 
-### Install Libreoffice/UNO ###
+### Install Libreoffice/UNO
 
-Libreoffice 4.1+ and Python-uno library are needed to enable office files online preview.
+Libreoffice 4.1+ and Python-uno library are required to enable office files online preview.
 
 On Ubuntu/Debian:
-```
+```bash
 sudo apt-get install libreoffice libreoffice-script-provider-python
 ```
 > For older version of Ubuntu: `sudo apt-get install libreoffice python-uno`
 
 On Centos/RHEL:
-```
+```bash
 sudo yum install libreoffice libreoffice-headless libreoffice-pyuno
 ```
 
-For other Linux distro: [Installation of LibreOffice on Linux](http://www.libreoffice.org/get-help/installation/linux/)
+For other Linux distributions: [Installation of LibreOffice on Linux](https://wiki.documentfoundation.org/Documentation/Install/Linux#Terminal-Based_Install)
 
-Also, you may need to install fonts for your language, especially for Asians, otherwise the  office/pdf document may not display correctly.
+Also, you may need to install fonts for your language, especially for Asians, otherwise the office/pdf document may not display correctly.
 
 For example, Chinese users may wish to install the WenQuanYi series of truetype fonts:
 
-```
+```bash
 # For ubuntu/debian
 sudo apt-get install ttf-wqy-microhei ttf-wqy-zenhei xfonts-wqy
 ```
 
-### Install poppler-utils ###
+### Install poppler-utils
 
 The package poppler-utils is also required.
 
 On Ubuntu/Debian:
-```
+```bash
 sudo apt-get install poppler-utils
 ```
 
 On CentOS/Red Hat:
-```
+```bash
 sudo yum install poppler-utils
 ```
 
@@ -76,7 +76,7 @@ max-size = 2
 
 ```
 
-## <a id="wiki-doc-preview"></a>FAQ about Office/PDF document preview ##
+## <a id="wiki-doc-preview"></a>FAQ about Office/PDF document preview
 
 - Document preview doesn't work, where to find more information?
 
@@ -112,7 +112,7 @@ Current office online preview works with libreoffice 4.0-4.2. If the version of 
 ```
 sudo apt-get remove libreoffice* python-uno python3-uno
 ```
-- Download libreoffice packages from [libreoffice official site](http://sourceforge.net/projects/libreoffice.mirror/files/LibreOffice%204.1.6/)
+- Download libreoffice packages from [libreoffice official site](https://downloadarchive.documentfoundation.org/libreoffice/old/)
 
 - Install the downloaded pacakges:
 ```


### PR DESCRIPTION
also fixes https://www.gitbook.com/book/seafile/seafile-server-manual/discussions/5

One remaining question is whether this is still the case:

> Current office online preview works with libreoffice 4.0-4.2