### PR TITLE
WIP: improve contribution.md

### DIFF
--- a/contribution.md
+++ b/contribution.md
@@ -2,13 +2,13 @@
 
 ## Licensing
 
-The different components of Seafile project are released under different licenses:
+The different components of Seafile are released under different licenses:
 
-* [Seafile iOS client](https://github.com/haiwen/seafile-iOS): Apache License v2
+* [Seafile iOS client](https://github.com/haiwen/seafile-iOS): [Apache License v2](https://github.com/haiwen/seafile-iOS/blob/master/LICENSE.txt)
 * [Seafile Android client](https://github.com/haiwen/seadroid): GPLv3
-* Desktop syncing client: GPLv2
-* [Seafile Server core](https://github.com/haiwen/seafile-server): AGPLv3
-* Seahub (Seafile server Web UI): Apache License v2
+* [Seafile Desktop client](https://github.com/haiwen/seafile-client): GPLv2
+* [Seafile Server core](https://github.com/haiwen/seafile-server): [AGPLv3](https://github.com/haiwen/seafile-server/blob/master/LICENSE.txt)
+* [Seahub](https://github.com/haiwen/seahub) (Seafile Server Web UI): [Apache License v2](https://github.com/haiwen/seahub/blob/master/LICENSE.txt)
 
 
 ## Discussion
@@ -19,7 +19,8 @@ Follow us @seafile https://twitter.com/seafile
 
 ## Report a Bug
 
-- Find the existing issues that fit your situation if any, or create a new issue. We are using Github as our issue tracker https://github.com/haiwen/seafile/issues?state=open
+Find the existing issues that fit your situation if any, or create a new issue. We are using Github as our issue tracker https://github.com/haiwen/seafile/issues?state=open
 
 ## Code Style
-  The source code of seafile is ISO/IEC 9899:1999 (E) (a.k.a. C99) compatible. Take a look at [code standard](develop/code_standard.md).
+
+The source code of Seafile is ISO/IEC 9899:1999 (E) (a.k.a. C99) compatible. Take a look at [code standard](develop/code_standard.md).


### PR DESCRIPTION
@freeplant it also looks like the listed licenses to not reflect the current state.

According to the repos
 * https://github.com/haiwen/seafile-client/blob/master/LICENSE is Apache License v2 instead of GPLv2
 * https://github.com/haiwen/seadroid/blob/master/LICENSE.md is AGPLv3 or later instead of GPLv2

Also there are missing parts:
 * seafdav is MIT according to https://github.com/haiwen/seafdav/blob/master/LICENSE
 * seafile-docker Apache V2 according to  https://github.com/haiwen/seafile-docker/blob/master/LICENSE.txt
 * seafile-server-installer AGPLv3 according to https://github.com/haiwen/seafile-server-installer/blob/master/LICENSE.txt
 * libsearpc Apache V2 according to https://github.com/haiwen/libsearpc/blob/master/LICENSE.txt 
 * seafile-user-manual Apache V2 according to https://github.com/haiwen/seafile-user-manual/blob/master/LICENSE.txt
 * seafile-docs Apache V2 according to https://github.com/haiwen/seafile-docs/blob/master/LICENSE.txt