### PR TITLE
Fixed non-HTTPS redirects in some cases

### DIFF
--- a/deploy/https_with_nginx.md
+++ b/deploy/https_with_nginx.md
@@ -122,7 +122,9 @@ Here is the sample configuration file:
 #         fastcgi_param	 SERVER_PORT         $server_port;
 #         fastcgi_param	 SERVER_NAME         $server_name;
 #         fastcgi_param   REMOTE_ADDR         $remote_addr;
-#     	 fastcgi_read_timeout 36000;
+#         fastcgi_param HTTPS on;
+#         fastcgi_param HTTP_SCHEME https;
+#     	  fastcgi_read_timeout 36000;
 #
 #         client_max_body_size 0;
 #


### PR DESCRIPTION
This affects FastCGI setups. By calling `https://seafileurl.com` a 302 to `http://seafileurl.com/accounts/login?next=/` is made.

see https://github.com/haiwen/seafile/issues/1519#issuecomment-198199794