### PR TITLE
add python-requests dependency for basic webserver

### DIFF
--- a/deploy/using_mysql.md
+++ b/deploy/using_mysql.md
@@ -90,12 +90,13 @@ The Seafile server package requires the following packages to be installed on yo
 * python-mysqldb
 * python-urllib3
 * python-memcache (or python-memcached)
+* python-requests
 
 ```
 # on Debian/Ubuntu 14.04 server
 apt-get update
 apt-get install python2.7 libpython2.7 python-setuptools python-imaging \
-  python-ldap python-mysqldb python-memcache python-urllib3
+  python-ldap python-mysqldb python-memcache python-urllib3 python-requests
 ```
 
 ```
@@ -103,7 +104,7 @@ apt-get install python2.7 libpython2.7 python-setuptools python-imaging \
 # As the default python binary on Ubuntu 16.04 server is python 3, we need to install python (python 2) first.
 apt-get update
 apt-get install python
-apt-get install python2.7 libpython2.7 python-setuptools python-imaging python-ldap python-urllib3 ffmpeg python-pip python-mysqldb python-memcache
+apt-get install python2.7 libpython2.7 python-setuptools python-imaging python-ldap python-urllib3 ffmpeg python-pip python-mysqldb python-memcache python-requests
 pip install pillow moviepy
 ```
 
@@ -111,7 +112,7 @@ pip install pillow moviepy
 # on CentOS 7
 yum -y install epel-release
 rpm --import http://li.nux.ro/download/nux/RPM-GPG-KEY-nux.ro
-yum -y install python-imaging MySQL-python python-memcached python-ldap python-urllib3 ffmpeg ffmpeg-devel
+yum -y install python-imaging MySQL-python python-memcached python-ldap python-urllib3 ffmpeg ffmpeg-devel python-requests
 pip install pillow moviepy
 ```
 


### PR DESCRIPTION
If a user wishes to install following these instructions and does not setup nginx/apache, then they will not be able to access the web interface.  If you follow the current instructions you will get an HTTP 500 error when loading the seafile webui at HOSTNAME:8000, this is because there is no webserver installed, not even a minimal one like python-requests.  I propose that following the barebones instructions should install at least a minimal webui.