### PR TITLE
Fixed a bug that did cause error logs.

### DIFF
--- a/maintain/seafile_gc.md
+++ b/maintain/seafile_gc.md
@@ -154,20 +154,22 @@ Use your favorite text editor and paste the following code:
 # stop the server
 echo Stopping the Seafile-Server...
 systemctl stop seafile.service
+systemctl stop seahub.service
 
 echo Giving the server some time to shut down properly....
-sleep 10
+sleep 20
 
 # run the cleanup
 echo Seafile cleanup started...
 sudo -u seafile $pathtoseafile/seafile-server-latest/seaf-gc.sh -r
 
 echo Giving the server some time....
-sleep 3
+sleep 10
 
 # start the server again
 echo Starting the Seafile-Server...
 systemctl start seafile.service
+systemctl start seahub.service
 
 echo Seafile cleanup done!
 ```


### PR DESCRIPTION
In the GC script for the CE version I did add so it also starts and stops seahub.service and I did increase the sleep time to 20 and 10 seconds.
It's needed because otherwise it will cause a error in seahub_django_request.log and that's because in the previous script it never did shutdown seahub.service it did only shutdown seafile.service.