### PR TITLE
Fixed a the GC script.

### DIFF
--- a/maintain/seafile_gc.md
+++ b/maintain/seafile_gc.md
@@ -161,7 +161,7 @@ sleep 20
 
 # run the cleanup
 echo Seafile cleanup started...
-sudo -u seafile $pathtoseafile/seafile-server-latest/seaf-gc.sh -r
+sudo -u seafile $pathtoseafile/seafile-server-latest/seaf-gc.sh
 
 echo Giving the server some time....
 sleep 10


### PR DESCRIPTION
I did delete the "-r" in the end of this line: sudo -u seafile $pathtoseafile/seafile-server-latest/seaf-gc.sh
If you run it with the "-r" in the end of the line it don't clean up, but if you run with without the -r then it works correctly.
It has been reported in the forum and also I have tried it by my self and I can confirmed that it works without the -r