### PR TITLE
Set systemd service type to forking

### DIFF
--- a/deploy/start_seafile_at_system_bootup.md
+++ b/deploy/start_seafile_at_system_bootup.md
@@ -21,10 +21,9 @@ The content of the file is:
     After=network.target
 
     [Service]
-    Type=oneshot
+    Type=forking
     ExecStart=${seafile_dir}/seafile-server-latest/seafile.sh start
     ExecStop=${seafile_dir}/seafile-server-latest/seafile.sh stop
-    RemainAfterExit=yes
     User=seafile
     Group=seafile
 
@@ -42,13 +41,12 @@ The content of the file is (please dont forget to change it if you want to run f
     After=network.target seafile.service
 
     [Service]
+    Type=forking
     # change start to start-fastcgi if you want to run fastcgi
     ExecStart=${seafile_dir}/seafile-server-latest/seahub.sh start
     ExecStop=${seafile_dir}/seafile-server-latest/seahub.sh stop
     User=seafile
     Group=seafile
-    Type=oneshot
-    RemainAfterExit=yes
 
     [Install]
     WantedBy=multi-user.target

--- a/deploy_pro/enable_search_and_background_tasks_in_a_cluster.md
+++ b/deploy_pro/enable_search_and_background_tasks_in_a_cluster.md
@@ -121,10 +121,9 @@ Description=Seafile Background Tasks Server
 After=network.target seahub.service
 
 [Service]
-Type=oneshot
+Type=forking
 ExecStart=/opt/seafile/seafile-server-latest/seafile-background-tasks.sh start
 ExecStop=/opt/seafile/seafile-server-latest/seafile-background-tasks.sh stop
-RemainAfterExit=yes
 User=root
 Group=root
 


### PR DESCRIPTION
From https://www.freedesktop.org/software/systemd/man/systemd.service.html#Type=:
> If set to forking, it is expected that the process configured with ExecStart= will call fork() as part of its start-up. The parent process is expected to exit when start-up is complete and all communication channels are set up. The child continues to run as the main daemon process. This is the behavior of traditional UNIX daemons. If this setting is used, it is recommended to also use the PIDFile= option, so that systemd can identify the main process of the daemon. systemd will proceed with starting follow-up units as soon as the parent process exits.