### PR TITLE
Add doc for nginx non standard port usage

### DIFF
--- a/faq/README.md
+++ b/faq/README.md
@@ -246,23 +246,24 @@ This is going to tell every node to generate the CSS CACHE in its local folder.
 
 ## Use non standard nginx port
 
-If you want to use a non standard nginx port other than 80 you have to modify following configuration settings:
+If you want to use a non standard nginx port other than 80 you have to add your non standard port `yourNginxPort` in following configuration settings:
 
-Change ccnet.conf
+### ccnet.conf
 
-  `SERVICE_URL = https://yourSeafileURL:yourNginxPort`
+`SERVICE_URL = https://yourSeafileURL:yourNginxPort`
 
-Change seahub_settings.py
+### seahub_settings.py
+`FILE_SERVER_ROOT = https://yourSeafileURL:yourNginxPort/seafhttp`
 
-	`FILE_SERVER_ROOT = https://yourSeafileURL:yourNginxPort/seafhttp`
-	`SITE_BASE = https://yourSeafileURL:yourNginxPort`
+`SITE_BASE = https://yourSeafileURL:yourNginxPort`
 
-Change nginx config file for seafile:
+### nginx config file
 
 ```
   server {
-    listen yourNginxPort; # <--------------------------------------- Non standard PORT
+    listen yourNginxPort; 
     ...
   location / {
     ...
-	proxy_set_header   Host $host:$server_port;```
+	proxy_set_header   Host $host:$server_port;
+```

--- a/faq/README.md
+++ b/faq/README.md
@@ -242,3 +242,27 @@ This is going to tell every node to generate the CSS CACHE in its local folder.
 ## Client
 
 * [Common problems about desktop syncing client](client.md)
+
+
+## Use non standard nginx port
+
+If you want to use a non standard nginx port other than 80 you have to modify following configuration settings:
+
+Change ccnet.conf
+
+  `SERVICE_URL = https://yourSeafileURL:yourNginxPort`
+
+Change seahub_settings.py
+
+	`FILE_SERVER_ROOT = https://yourSeafileURL:yourNginxPort/seafhttp`
+	`SITE_BASE = https://yourSeafileURL:yourNginxPort`
+
+Change nginx config file for seafile:
+
+```
+  server {
+    listen yourNginxPort; # <--------------------------------------- Non standard PORT
+    ...
+  location / {
+    ...
+	proxy_set_header   Host $host:$server_port;```


### PR DESCRIPTION
Add missing doc for nginx configuration which config files have to be updated in order to use a non standard nginx port