### PR TITLE
Add ProxyPreserveHost On to Apache config blocks

### DIFF
--- a/deploy/deploy_seahub_at_non-root_domain.md
+++ b/deploy/deploy_seahub_at_non-root_domain.md
@@ -120,6 +120,7 @@ Here is the sample configuration:
   #
   SetEnvIf Request_URI . proxy-fcgi-pathinfo=unescape
   SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
+  ProxyPreserveHost On
   ProxyPass /seafile fcgi://127.0.0.1:8000/seafile
 </VirtualHost>
 ```

--- a/deploy/deploy_with_apache.md
+++ b/deploy/deploy_with_apache.md
@@ -53,6 +53,7 @@ Modify Apache config file:
     # seahub
     #
     SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
+    ProxyPreserveHost On
     ProxyPass / http://127.0.0.1:8000/
     ProxyPassReverse / http://127.0.0.1:8000/
 </VirtualHost>

--- a/deploy/https_with_apache.md
+++ b/deploy/https_with_apache.md
@@ -76,6 +76,7 @@ Then modify your Apache configuration file. Here is a sample:
   # seahub
   #
   SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
+  ProxyPreserveHost On
   ProxyPass / http://127.0.0.1:8000/
   ProxyPassReverse / http://127.0.0.1:8000/
 </VirtualHost>

--- a/deploy/only_office.md
+++ b/deploy/only_office.md
@@ -451,6 +451,7 @@ LoadModule ssl_module modules/mod_ssl.so
   #
   SetEnvIf Request_URI . proxy-fcgi-pathinfo=unescape
   SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
+  ProxyPreserveHost	On
   ProxyPass / fcgi://127.0.0.1:8000/
   
   #

--- a/deploy/shibboleth_config.md
+++ b/deploy/shibboleth_config.md
@@ -87,6 +87,7 @@ You should create a new virtual host configuration for Shibboleth.
         RewriteRule ^/(media.*)$ /$1 [QSA,L,PT]
         RewriteCond %{REQUEST_FILENAME} !-f
         RewriteCond %{REQUEST_URI} !^/Shibboleth.sso
+        ProxyPreserveHost On
         RewriteRule ^(.*)$ /seahub.fcgi$1 [QSA,L,E=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
 
     </VirtualHost>

--- a/deploy/shibboleth_config_v6.3.md
+++ b/deploy/shibboleth_config_v6.3.md
@@ -84,6 +84,7 @@ You should create a new virtual host configuration for Shibboleth.
         #
         # seahub
         #
+        ProxyPreserveHost On
         ProxyPass / http://127.0.0.1:8000/
         ProxyPassReverse / http://127.0.0.1:8000/
 

--- a/deploy_windows/deploy_with_apache.md
+++ b/deploy_windows/deploy_with_apache.md
@@ -64,6 +64,7 @@ Then add the following lines:
     #
     SetEnvIf Request_URI . proxy-fcgi-pathinfo=unescape
     SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
+    ProxyPreserveHost On
     ProxyPass / fcgi://127.0.0.1:8000/
 </VirtualHost>
 ```

--- a/extension/webdav.md
+++ b/extension/webdav.md
@@ -182,6 +182,7 @@ Based on your apache configuration when you [deploy Seafile with Apache](,,/depl
     #
     SetEnvIf Request_URI . proxy-fcgi-pathinfo=unescape
     SetEnvIf Authorization "(.*)" HTTP_AUTHORIZATION=$1
+    ProxyPreserveHost On
     ProxyPass / fcgi://127.0.0.1:8000/
 
 </virtualhost>


### PR DESCRIPTION
This ensures that Django in Seahub behind the Proxy will see the correct
Host header for incoming requests and - in turn - render correct results
for `request.build_absolute_uri`.

Without this directive, no avatars are rendered on user search for sharing a library.