### PR TITLE
fix location /media rule

### DIFF
--- a/deploy/deploy_with_nginx.md
+++ b/deploy/deploy_with_nginx.md
@@ -74,7 +74,7 @@ server {
         send_timeout  36000s;
     }
     location /media {
-        root /home/user/haiwen/seafile-server-latest/seahub;
+        root /home/user/haiwen/seafile-server-latest/seahub/media;
     }
 }
 ```


### PR DESCRIPTION
The location "/media" must point to /home/user/haiwen/seafile-server-latest/seahub/media