### PR TITLE
Update enable_search_and_background_tasks_in_a_cluster.md

### DIFF
--- a/deploy_pro/enable_search_and_background_tasks_in_a_cluster.md
+++ b/deploy_pro/enable_search_and_background_tasks_in_a_cluster.md
@@ -63,6 +63,7 @@ On nodes B and C, you need to:
 * Edit `seafevents.conf`, add the following lines:
 ```
 [INDEX FILES]
+enabled = true
 external_es_server = true
 es_host = <ip of node A>
 es_port = 9200


### PR DESCRIPTION
```ini
[INDEX FILES]
enabled = true
```
is also required on the frontend nodes, like stated on https://github.com/haiwen/seafile-docs/blob/master/deploy_pro/deploy_in_a_cluster.md#seafeventsconf